### PR TITLE
二重投稿、レスコメント、描画時間記録の仕様の変更

### DIFF
--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -215,12 +215,11 @@ $smarty->assign('usercode',$usercode);
 function regist() {
 	global $name,$com,$sub,$parent,$picfile,$img_w,$img_h,$mail,$url,$time,$pwd,$pwdh,$exid,$invz;
 	global $badip;
-	global $req_method,$temppath;
+	global $req_method;
 	global $smarty;
 	$userip = get_uip();
 
-	// $ptime = newstring(trim(filter_input(INPUT_POST, 'ptime')));
-	$secptime = newstring(filter_input(INPUT_POST, 'secptime'));
+	$secptime = filter_input(INPUT_POST, 'secptime' ,FILTER_VALIDATE_BOOLEAN);
 
 	if($req_method !== "POST") {error(MSG006);exit;}
 
@@ -247,7 +246,7 @@ function regist() {
 	$ptime='';
 	if($picfile){
 		$path_filename=pathinfo($picfile, PATHINFO_FILENAME );//拡張子除去
-		$fp = fopen($temppath.$path_filename.".dat", "r");
+		$fp = fopen(TEMP_DIR.$path_filename.".dat", "r");
 		$userdata = fread($fp, 1024);
 		fclose($fp);
 		list($uip,$uhost,,,$ucode,,$starttime,$postedtime) = explode("\t", rtrim($userdata));
@@ -256,7 +255,6 @@ function regist() {
 			$ptime = calcPtime($starttime,$postedtime);
 		}
 	}
-
 
 	//投稿時間を隠す設定
 	if($secptime == true) {
@@ -973,8 +971,6 @@ function paintform(){
 
 	$smarty->assign('path',IMG_DIR);
 
-	// $smarty->assign('usercode',$usercode);
-
 	$smarty->assign('stime',time());
 	
 	$userip = get_uip();
@@ -1023,7 +1019,7 @@ function paintform(){
 		$imgfile = filter_input(INPUT_POST, 'img');
 		$smarty->assign('imgfile',IMG_DIR.$imgfile);
 	}
-	$usercode.='&amp;stime='.time();
+	$usercode.='&amp;stime='.time();//拡張ヘッダに描画開始時間をセット
 	//差し換え時の認識コード追加
 	if($type==='rep'){
 		$no = filter_input(INPUT_POST, 'no',FILTER_VALIDATE_INT);
@@ -1037,11 +1033,9 @@ function paintform(){
 		$pwdf = bin2hex($pwdf);//16進数に
 		$datmode = 'picrep&amp;no='.$no.'&amp;pwd='.$pwdf.'&amp;repcode='.$repcode;
 		$smarty->assign('mode',$datmode);
-		// $datusercode = $usercode.'&amp;repcode='.$repcode;
 		$usercode.='&amp;repcode='.$repcode;
-		// $smarty->assign('usercode',$datusercode);
 	}
-		$smarty->assign('usercode',$usercode);
+		$smarty->assign('usercode',$usercode);//usercodeにいろいろくっついたものをまとめて出力
 
 	//出力
 	$smarty->display( THEMEDIR.PAINTFILE );

--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -1420,12 +1420,15 @@ function picreplace($no,$pwdf,$stime){
 			if ( $picfile == true ) {
 				rename( TEMP_DIR.$picfile , IMG_DIR.$picfile );
 				chmod( IMG_DIR.$picfile , 0606);
-				$picdat = strtr($picfile , 'png', 'dat');
+				// $picdat = strtr($picfile , 'png', 'dat');
+				$picdat = $file_name.'.dat';
 				rename( TEMP_DIR.$picdat, IMG_DIR.$picdat );
 				chmod( IMG_DIR.$picdat , 0606);
 
-				$spchfile = str_replace('png','spch', $picfile);
-				$pchfile = strtr($picfile , 'png', 'pch');
+				// $spchfile = str_replace('png','spch', $picfile);
+				// $pchfile = strtr($picfile , 'png', 'pch');
+				$pchfile = $file_name.'.pch';
+				$spchfile = $file_name.'.spch';
 				
 				if ( file_exists(TEMP_DIR.$pchfile) == TRUE ) {
 					rename( TEMP_DIR.$pchfile, IMG_DIR.$pchfile );
@@ -1443,7 +1446,8 @@ function picreplace($no,$pwdf,$stime){
 			//旧ファイル削除
 			if(is_file($path.$msg_d["picfile"])) unlink($path.$msg_d["picfile"]);
 			if(is_file($path.$msg_d["pchfile"])) unlink($path.$msg_d["pchfile"]);
-			$msgedat = str_replace( strrchr($msg_d["picfile"],"."), "", $msg_d["picfile"]); //拡張子除去
+			// $msgedat = str_replace( strrchr($msg_d["picfile"],"."), "", $msg_d["picfile"]); //拡張子除去
+			$msgedat = pathinfo($msg_d["picfile"], PATHINFO_FILENAME );//拡張子除去
 			$msgedat = $msgedat.'.dat';
 			if(is_file($path.$msgedat)) unlink($path.$msgedat);
 			//描画時間追加

--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -304,17 +304,16 @@ function regist() {
 
 			//画像ファイルとか処理
 			if ( $picfile == true ) {
-				$imagesize = getimagesize(TEMP_DIR.$picfile);
-				$img_w = $imagesize[0];
-				$img_h = $imagesize[1];
+				list($img_w,$img_h)=getimagesize(TEMP_DIR.$picfile);
 				rename( TEMP_DIR.$picfile , IMG_DIR.$picfile );
 				chmod( IMG_DIR.$picfile , 0606);
-				$picdat = strtr($picfile , 'png', 'dat');
+				$path_filename=pathinfo($picfile, PATHINFO_FILENAME );//拡張子除去
+				$picdat = $path_filename.'.dat';
 				rename( TEMP_DIR.$picdat, IMG_DIR.$picdat );
 				chmod( IMG_DIR.$picdat , 0606);
 
-				$spchfile = str_replace('png','spch', $picfile);
-				$pchfile = strtr($picfile , 'png', 'pch');
+				$spchfile = $path_filename.'.spch';
+				$pchfile = $path_filename.'.pch';
 				
 				if ( file_exists(TEMP_DIR.$pchfile) == TRUE ) {
 					rename( TEMP_DIR.$pchfile, IMG_DIR.$pchfile );
@@ -384,7 +383,7 @@ function regist() {
 				$msgpic = $msg["picfile"]; //画像の名前取得できた
 				//画像とかの削除処理
 				if (file_exists(IMG_DIR.$msgpic)) {
-					$msgdat = str_replace( strrchr($msgpic,"."), "", $msgpic); //拡張子除去
+					$msgdat =pathinfo($msgpic, PATHINFO_FILENAME );//拡張子除去
 					if (file_exists(IMG_DIR.$msgdat.'.png')) {
 						unlink(IMG_DIR.$msgdat.'.png');
 					}
@@ -426,7 +425,8 @@ function regist() {
 					$msgpic = $msg["picfile"]; //画像の名前取得できた
 					//画像とかの削除処理
 					if (file_exists(IMG_DIR.$msgpic)) {
-						$msgdat = str_replace( strrchr($msgpic,"."), "", $msgpic); //拡張子除去
+						$msgdat =pathinfo($msgpic, PATHINFO_FILENAME );//拡張子除去
+
 						if (file_exists(IMG_DIR.$msgdat.'.png')) {
 						unlink(IMG_DIR.$msgdat.'.png');
 						}

--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -89,6 +89,7 @@ function newstring($string) {
 }
 //無効化ここまで
 
+
 /* オートリンク */
 function auto_link($proto){
 	if(!(stripos($proto,"script")!==false)){//scriptがなければ続行
@@ -225,9 +226,9 @@ function regist() {
 
 	//NGワードがあれば拒絶
 	Reject_if_NGword_exists_in_the_post($com,$name,$mail,$url,$sub);
-
-
 	if(USE_NAME&&!$name) {error(MSG009);exit;}
+	//レスの時は本文必須
+	if(filter_input(INPUT_POST, 'modid')&&!$com) {error(MSG008);exit;}
 	if(USE_COM&&!$com) {error(MSG008);exit;}
 	if(USE_SUB&&!$sub) {error(MSG010);exit;}
 
@@ -285,7 +286,7 @@ function regist() {
 				$msgwcom = $msgwc["com"]; //最新コメント取得できた
 				$msgwhost = $msgwc["host"]; //最新ホスト取得できた
 				//どれも一致すれば二重投稿だと思う
-				if($com == $msgwcom && $host == $msgwhost && $sub == $msgsub ){
+				if($com != DEF_COM && $com == $msgwcom && $host == $msgwhost && $sub == $msgsub ){
 					$msgs = null;
 					$msgw = null;
 					$db = null; //db切断

--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -244,15 +244,17 @@ function regist() {
 		if(preg_match("/$value$/i",$host)) {error(MSG016);exit;}
 	}
 	//↑セキュリティ関連ここまで
-	$path_filename=pathinfo($picfile, PATHINFO_FILENAME );//拡張子除去
-	$fp = fopen($temppath.$path_filename.".dat", "r");
-	$userdata = fread($fp, 1024);
-	fclose($fp);
-	list($uip,$uhost,,,$ucode,,$starttime,$postedtime) = explode("\t", rtrim($userdata));
 	$ptime='';
-	//描画時間を$userdataをもとに計算
-	if($starttime && DSP_PAINTTIME){
-		$ptime = calcPtime($starttime,$postedtime);
+	if($picfile){
+		$path_filename=pathinfo($picfile, PATHINFO_FILENAME );//拡張子除去
+		$fp = fopen($temppath.$path_filename.".dat", "r");
+		$userdata = fread($fp, 1024);
+		fclose($fp);
+		list($uip,$uhost,,,$ucode,,$starttime,$postedtime) = explode("\t", rtrim($userdata));
+		//描画時間を$userdataをもとに計算
+		if($starttime && DSP_PAINTTIME){
+			$ptime = calcPtime($starttime,$postedtime);
+		}
 	}
 
 
@@ -326,10 +328,10 @@ function regist() {
 				$spchfile = $path_filename.'.spch';
 				$pchfile = $path_filename.'.pch';
 				
-				if ( file_exists(TEMP_DIR.$pchfile) == TRUE ) {
+				if ( is_file(TEMP_DIR.$pchfile) == TRUE ) {
 					rename( TEMP_DIR.$pchfile, IMG_DIR.$pchfile );
 					chmod( IMG_DIR.$pchfile , 0606);
-				} elseif( file_exists(TEMP_DIR.$spchfile) == TRUE ) {
+				} elseif( is_file(TEMP_DIR.$spchfile) == TRUE ) {
 					rename( TEMP_DIR.$spchfile, IMG_DIR.$spchfile );
 					chmod( IMG_DIR.$spchfile , 0606);
 					$pchfile = $spchfile;
@@ -393,21 +395,21 @@ function regist() {
 				$msg = $msgs->fetch();
 				$msgpic = $msg["picfile"]; //画像の名前取得できた
 				//画像とかの削除処理
-				if (file_exists(IMG_DIR.$msgpic)) {
+				if (is_file(IMG_DIR.$msgpic)) {
 					$msgdat =pathinfo($msgpic, PATHINFO_FILENAME );//拡張子除去
-					if (file_exists(IMG_DIR.$msgdat.'.png')) {
+					if (is_file(IMG_DIR.$msgdat.'.png')) {
 						unlink(IMG_DIR.$msgdat.'.png');
 					}
-					if (file_exists(IMG_DIR.$msgdat.'.jpg')) {
+					if (is_file(IMG_DIR.$msgdat.'.jpg')) {
 						unlink(IMG_DIR.$msgdat.'.jpg'); //一応jpgも
 					}
-					if (file_exists(IMG_DIR.$msgdat.'.pch')) {
+					if (is_file(IMG_DIR.$msgdat.'.pch')) {
 						unlink(IMG_DIR.$msgdat.'.pch'); 
 					}
-					if (file_exists(IMG_DIR.$msgdat.'.spch')) {
+					if (is_file(IMG_DIR.$msgdat.'.spch')) {
 						unlink(IMG_DIR.$msgdat.'.spch'); 
 					}
-					if (file_exists(IMG_DIR.$msgdat.'.dat')) {
+					if (is_file(IMG_DIR.$msgdat.'.dat')) {
 						unlink(IMG_DIR.$msgdat.'.dat'); 
 					}
 				}
@@ -435,22 +437,22 @@ function regist() {
 					$msg = $msgs->fetch();
 					$msgpic = $msg["picfile"]; //画像の名前取得できた
 					//画像とかの削除処理
-					if (file_exists(IMG_DIR.$msgpic)) {
+					if (is_file(IMG_DIR.$msgpic)) {
 						$msgdat =pathinfo($msgpic, PATHINFO_FILENAME );//拡張子除去
 
-						if (file_exists(IMG_DIR.$msgdat.'.png')) {
+						if (is_file(IMG_DIR.$msgdat.'.png')) {
 						unlink(IMG_DIR.$msgdat.'.png');
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.jpg')) {
+						if (is_file(IMG_DIR.$msgdat.'.jpg')) {
 							unlink(IMG_DIR.$msgdat.'.jpg'); //一応jpgも
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.pch')) {
+						if (is_file(IMG_DIR.$msgdat.'.pch')) {
 							unlink(IMG_DIR.$msgdat.'.pch'); 
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.spch')) {
+						if (is_file(IMG_DIR.$msgdat.'.spch')) {
 							unlink(IMG_DIR.$msgdat.'.spch'); 
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.dat')) {
+						if (is_file(IMG_DIR.$msgdat.'.dat')) {
 							unlink(IMG_DIR.$msgdat.'.dat'); 
 						}
 					}
@@ -491,21 +493,21 @@ function regist() {
 					$msg = $msgs->fetch();
 					$msgpic = $msg["picfile"]; //画像の名前取得できた
 					//画像とかの削除処理
-					if (file_exists(IMG_DIR.$msgpic)) {
+					if (is_file(IMG_DIR.$msgpic)) {
 						$msgdat = str_replace( strrchr($msgpic,"."), "", $msgpic); //拡張子除去
-						if (file_exists(IMG_DIR.$msgdat.'.png')) {
+						if (is_file(IMG_DIR.$msgdat.'.png')) {
 						unlink(IMG_DIR.$msgdat.'.png');
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.jpg')) {
+						if (is_file(IMG_DIR.$msgdat.'.jpg')) {
 							unlink(IMG_DIR.$msgdat.'.jpg'); //一応jpgも
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.pch')) {
+						if (is_file(IMG_DIR.$msgdat.'.pch')) {
 							unlink(IMG_DIR.$msgdat.'.pch'); 
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.spch')) {
+						if (is_file(IMG_DIR.$msgdat.'.spch')) {
 							unlink(IMG_DIR.$msgdat.'.spch'); 
 						}
-						if (file_exists(IMG_DIR.$msgdat.'.dat')) {
+						if (is_file(IMG_DIR.$msgdat.'.dat')) {
 							unlink(IMG_DIR.$msgdat.'.dat'); 
 						}
 					}
@@ -1143,7 +1145,7 @@ function paintcom(){
 			fclose($fp);
 			list($uip,$uhost,$uagent,$imgext,$ucode,) = explode("\t", rtrim($userdata));
 			$file_name = preg_replace("/\.(dat)$/i","",$file);
-			if(file_exists(TEMP_DIR.$file_name.$imgext)) //画像があればリストに追加
+			if(is_file(TEMP_DIR.$file_name.$imgext)) //画像があればリストに追加
 				$tmplist[] = $ucode."\t".$uip."\t".$file_name.$imgext;
 		}
 	}
@@ -1304,21 +1306,21 @@ function delmode(){
 
 		if (password_verify($ppwd,$msg['pwd']) === true) {
 			//画像とかファイル削除
-			if (file_exists(IMG_DIR.$msgpic)) {
+			if (is_file(IMG_DIR.$msgpic)) {
 				$msgdat = str_replace( strrchr($msgpic,"."), "", $msgpic); //拡張子除去
-				if (file_exists(IMG_DIR.$msgdat.'.png')) {
+				if (is_file(IMG_DIR.$msgdat.'.png')) {
 					unlink(IMG_DIR.$msgdat.'.png');
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.jpg')) {
+				if (is_file(IMG_DIR.$msgdat.'.jpg')) {
 					unlink(IMG_DIR.$msgdat.'.jpg'); //一応jpgも
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.pch')) {
+				if (is_file(IMG_DIR.$msgdat.'.pch')) {
 					unlink(IMG_DIR.$msgdat.'.pch'); 
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.spch')) {
+				if (is_file(IMG_DIR.$msgdat.'.spch')) {
 					unlink(IMG_DIR.$msgdat.'.spch'); 
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.dat')) {
+				if (is_file(IMG_DIR.$msgdat.'.dat')) {
 					unlink(IMG_DIR.$msgdat.'.dat'); 
 				}
 			}
@@ -1329,21 +1331,21 @@ function delmode(){
 			$smarty->assign('message','削除しました。');
 		} elseif ($admin_pass == $ppwd && $admindelmode == 1) {
 			//画像とかファイル削除
-			if (file_exists(IMG_DIR.$msgpic)) {
+			if (is_file(IMG_DIR.$msgpic)) {
 				$msgdat = str_replace( strrchr($msgpic,"."), "", $msgpic); //拡張子除去
-				if (file_exists(IMG_DIR.$msgdat.'.png')) {
+				if (is_file(IMG_DIR.$msgdat.'.png')) {
 					unlink(IMG_DIR.$msgdat.'.png');
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.jpg')) {
+				if (is_file(IMG_DIR.$msgdat.'.jpg')) {
 					unlink(IMG_DIR.$msgdat.'.jpg'); //一応jpgも
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.pch')) {
+				if (is_file(IMG_DIR.$msgdat.'.pch')) {
 					unlink(IMG_DIR.$msgdat.'.pch'); 
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.spch')) {
+				if (is_file(IMG_DIR.$msgdat.'.spch')) {
 					unlink(IMG_DIR.$msgdat.'.spch'); 
 				}
-				if (file_exists(IMG_DIR.$msgdat.'.dat')) {
+				if (is_file(IMG_DIR.$msgdat.'.dat')) {
 					unlink(IMG_DIR.$msgdat.'.dat'); 
 				}
 			}
@@ -1399,7 +1401,7 @@ function picreplace($no,$pwdf){
 			$userdata = fread($fp, 1024);
 			fclose($fp);
 			list($uip,$uhost,$uagent,$imgext,$ucode,$urepcode,$starttime,$postedtime) = explode("\t", rtrim($userdata)."\t");//区切りの"\t"を行末に190610
-			$file_name = preg_replace("/\.(dat)$/i","",$file);
+			$file_name = pathinfo($file, PATHINFO_FILENAME );//拡張子除去
 			//画像があり、認識コードがhitすれば抜ける 
 			if($file_name && is_file(TEMP_DIR.$file_name.$imgext) && $urepcode === $repcode){
 				$find=true;
@@ -1415,7 +1417,7 @@ function picreplace($no,$pwdf){
 
 	//描画時間
 	$ptime='';
-	if($starttime){
+	if($starttime && DSP_PAINTTIME){
 		$ptime = calcPtime($starttime,$postedtime);
 	}
 
@@ -1444,10 +1446,10 @@ function picreplace($no,$pwdf){
 				$pchfile = $file_name.'.pch';
 				$spchfile = $file_name.'.spch';
 				
-				if ( file_exists(TEMP_DIR.$pchfile) == TRUE ) {
+				if ( is_file(TEMP_DIR.$pchfile) == TRUE ) {
 					rename( TEMP_DIR.$pchfile, IMG_DIR.$pchfile );
 					chmod( IMG_DIR.$pchfile , 0606);
-				} elseif( file_exists(TEMP_DIR.$spchfile) == TRUE ) {
+				} elseif( is_file(TEMP_DIR.$spchfile) == TRUE ) {
 					rename( TEMP_DIR.$spchfile, IMG_DIR.$spchfile );
 					chmod( IMG_DIR.$spchfile , 0606);
 					$pchfile = $spchfile;
@@ -1759,7 +1761,7 @@ function error2() {
 
 function init(){
 	try {
-		if (!file_exists('noe.db')) {
+		if (!is_file('noe.db')) {
 			// はじめての実行なら、テーブルを作成
 			$db = new PDO("sqlite:noe.db");
 			$db->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);  

--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -267,6 +267,8 @@ function regist() {
 		$db = new PDO("sqlite:noe.db");
 		if (isset($_POST["send"] ) ===  true) {
 
+			$strlen_com=strlen($com);
+
 			if ( $name   === "" ) $name = DEF_NAME;
 			if ( $com  === "" ) $com  = DEF_COM;
 			if ( $sub  === "" ) $sub  = DEF_SUB;
@@ -297,7 +299,7 @@ function regist() {
 				$msgwcom = $msgwc["com"]; //最新コメント取得できた
 				$msgwhost = $msgwc["host"]; //最新ホスト取得できた
 				//どれも一致すれば二重投稿だと思う
-				if($com != DEF_COM && $com == $msgwcom && $host == $msgwhost && $sub == $msgsub ){
+				if($strlen_com > 0 && $com == $msgwcom && $host == $msgwhost && $sub == $msgsub ){
 					$msgs = null;
 					$msgw = null;
 					$db = null; //db切断

--- a/noe-board/picpost.php
+++ b/noe-board/picpost.php
@@ -1,6 +1,6 @@
 <?php
 //----------------------------------------------------------------------
-// picpost.php lot.200302  by SakaQ >> http://www.punyu.net/php/
+// picpost.php lot.200828  by SakaQ >> http://www.punyu.net/php/
 // & sakots >> https://poti-k.info/
 //
 // しぃからPOSTされたお絵かき画像をTEMPに保存
@@ -8,6 +8,8 @@
 // このスクリプトはPaintBBS（藍珠CGI）のPNG保存ルーチンを参考に
 // PHP用に作成したものです。
 //----------------------------------------------------------------------
+// 2020/08/28 描画時間の記録に対応
+// 2020/05/25 投稿容量制限の設定項目を追加 従来はconfigのMAX_KB
 // 2020/02/25 flock()修正タイムゾーンを'Asia/Tokyo'に
 // 2020/01/25 REMOTE_ADDRが取得できないサーバに対応
 // 2019/12/03 軽微なエラー修正。datファイルのパーミッションを600に
@@ -31,6 +33,8 @@ include(__DIR__.'/config.php');
 date_default_timezone_set('Asia/Tokyo');
 //容量違反チェックをする する:1 しない:0
 define('SIZE_CHECK', '1');
+//投稿容量制限 KB
+define('PICPOST_MAX_KB', '3072');//3MBまで
 
 $time = time();
 $imgfile = $time.substr(microtime(),2,3);	//画像ファイル名
@@ -95,7 +99,7 @@ $headerLength = substr($buffer, 1, 8);
 // 画像ファイルの長さを取り出す
 $imgLength = substr($buffer, 1 + 8 + $headerLength, 8);
 // 投稿容量制限を超えていたら保存しない
-if(SIZE_CHECK && ($imgLength > MAX_KB * 1024)){
+if(SIZE_CHECK && ($imgLength > PICPOST_MAX_KB * 1024)){
 	error("規定容量オーバー。お絵かき画像は保存されません。");
 	exit;
 }
@@ -198,8 +202,9 @@ if($sendheader){
 		list($name,$value) = explode("=", $query_s);
 		$$name = $value;
 	}
-	//usercodeと差し換え認識コード追加
-	$userdata .= "\t$usercode\t$repcode";
+	//usercode 差し換え認識コード 描画開始 完了時間 を追加
+	$userdata .= "\t$usercode\t$repcode\t$stime\t$time";
+
 }
 $userdata .= "\n";
 if(is_file(TEMP_DIR.$imgfile.".dat")){


### PR DESCRIPTION
### 二重投稿
同じコメントが投稿されると二重投稿ですか？というエラーがでます。
しかし、コメントが必須ではないときの「本文無し」も同じ「本文無し」というコメントになるので、二重投稿のエラーになります。
コメントの長さが 0 の時は本文が無い投稿なので、二重投稿のチェックをしないようにしました。
### レスのコメントを必須に
コメント未記入の「本文無し」がボタンを押すだけで延々と投稿できる形になってしまったので、レスの時は本文の入力を促すエラー処理になるようにしました。
### 投稿時間
拡張子.datのユーザーデータに描画開始時間と投稿完了時間を保存しておいて、それを元に描画時間を計算する方式に。
改二の最新板と同じ処理になりました。
picpost.phpの更新も必要です。
### コード整理
拡張子除去をphpのローカル関数で。
ファイルの存在確認はis_fileで。
ユーザーデータを記録したdatファイルは投稿が完了したら削除。改二ではワークファイル削除の箇所で削除しているので、それにあわせました。
しかし、行数オーバーや記事削除機能を使った時に一緒に削除する機能は残しました。
理由。すでに設置して運用している方のディレクトリには残っているから。

