### PR TITLE
投稿者名をコピーする機能の改良

### DIFF
--- a/noe-board/index.php
+++ b/noe-board/index.php
@@ -880,11 +880,22 @@ function res(){
 			$sqli = "SELECT * FROM tabletree WHERE (invz=0 AND tid=".$resno.") ORDER BY tree DESC";
 			$postsi = $db->query($sqli);
 			$ko = array();
+			$rresname = array();
 			while ($res = $postsi->fetch()){
 				$ko[] = $res;
+				if (!in_array($res['name'], $rresname)) {//重複除外
+					$rresname[] = $res['name'];//投稿者名を配列に入れる
+				}
+		
 				$smarty->assign('ko',$ko);
 			}
 			$oya[] = $bbsline;
+			if (!in_array($bbsline['name'], $rresname)) {
+				$rresname[] = $bbsline['name'];
+			}
+			$resname=implode('さん ',$rresname);
+			$smarty->assign('resname',$resname);
+
 			$smarty->assign('oya',$oya);
 		}
 		//そろそろ消える用

--- a/noe-board/templates/theme/mono_res.html
+++ b/noe-board/templates/theme/mono_res.html
@@ -14,7 +14,6 @@
 		<meta property="og:site_name"  content="">
 		<meta property="og:description" content="{$bbsline.com|strip_tags:false}">
 		{/foreach}
-		<script src="./templates/{$skindir}getresname.js"></script>
 	</head>
 	<body>
 		<header id="header">
@@ -101,9 +100,14 @@
 					{foreach from=$oya item=bbsline}{if isset($bbsline.com)}
 					<section>
 						<h3 class="oekaki">このスレにレス</h3>
+						<script>function add_to_com(){
+							document.getElementById("p_input_com").value += "{$resname}さん";
+						}
+						</script>
+	
 						{if $elapsed_time == 0 || $nowtime - $bbsline.utime < $elapsed_time}
 						<p>
-							<button class="copy_button" onclick="c();">投稿者名をコピー</button>
+							<button class="copy_button" onclick="add_to_com()">投稿者名をコピー</button>
 							（レスの投稿者名をクリップボードにコピーできます）
 						</p>
 						<form action="{$self}?mode=regist" method="post" class="postform">
@@ -142,7 +146,7 @@
 								<tr>
 									<td>comment{if $use_com == 1} *{/if}</td>
 									<td>
-										<textarea name="com" rows="4" cols="48"></textarea>
+										<textarea name="com" rows="4" cols="48" id="p_input_com"></textarea>
 									</td>
 								</tr>
 								<tr>

--- a/noe-board/templates/theme/mono_res.html
+++ b/noe-board/templates/theme/mono_res.html
@@ -108,7 +108,7 @@
 						{if $elapsed_time == 0 || $nowtime - $bbsline.utime < $elapsed_time}
 						<p>
 							<button class="copy_button" onclick="add_to_com()">投稿者名をコピー</button>
-							（レスの投稿者名をコピーできます）
+							（投稿者名をコピーできます）
 						</p>
 						<form action="{$self}?mode=regist" method="post" class="postform">
 							<table>

--- a/noe-board/templates/theme/mono_res.html
+++ b/noe-board/templates/theme/mono_res.html
@@ -108,7 +108,7 @@
 						{if $elapsed_time == 0 || $nowtime - $bbsline.utime < $elapsed_time}
 						<p>
 							<button class="copy_button" onclick="add_to_com()">投稿者名をコピー</button>
-							（レスの投稿者名をクリップボードにコピーできます）
+							（レスの投稿者名をコピーできます）
 						</p>
 						<form action="{$self}?mode=regist" method="post" class="postform">
 							<table>


### PR DESCRIPTION
投稿者名をコピーボタンを押すとクリップボードを経由せずコメント欄に取得した名前をいれる機能の実装。
名前が重複しません。
親と子どちらも取得するので、レスの返信者の名前しか取得しない改二とは少し動作が違います。
![image](https://user-images.githubusercontent.com/44894014/97709841-50876d00-1afe-11eb-927c-1a02dba40038.png)
